### PR TITLE
options.rootDir => options.entryRoot

### DIFF
--- a/parcel-namer-preserve-structure/index.js
+++ b/parcel-namer-preserve-structure/index.js
@@ -83,7 +83,7 @@ module.exports = (new Namer({
     // Base split bundle names on the first bundle in their group.
     // e.g. if `index.js` imports `foo.css`, the css bundle should be called
     //      `index.css`.
-    let name = nameFromContent(mainBundle, options.rootDir);
+    let name = nameFromContent(mainBundle, options.entryRoot);
     if (!bundle.isEntry) {
       name += "." + bundle.hashReference;
     }


### PR DESCRIPTION
Apply this change in options naming: https://github.com/parcel-bundler/parcel/commit/ada9d70cf48c2d0d8a21769c021b6d5e00988f07

Thanks for this plugin :wink: 