### PR TITLE
Replace options.entryRoot

### DIFF
--- a/parcel-namer-preserve-structure/index.js
+++ b/parcel-namer-preserve-structure/index.js
@@ -88,7 +88,7 @@ module.exports = (new Namer({
     let name = nameFromContent(
       mainBundle,
       bundleGroup.entryAssetId,
-      options.entryRoot
+      bundleGraph.getEntryRoot(bundle.target)
     );
     if (!bundle.isEntry) {
       name += "." + bundle.hashReference;


### PR DESCRIPTION
Replace options.entryRoot with bundleGraph.getEntryRoot(target).
See https://github.com/parcel-bundler/parcel/pull/6608/files